### PR TITLE
[Sharding] Message 를 별도 6개의 DB로 분리를 위한 샤딩 추가

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,1 +1,1 @@
-COMPOSE_PROJECT_NAME=message-system-add-correction
+COMPOSE_PROJECT_NAME=message-system-add-sharding

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -44,6 +44,96 @@ services:
       --enforce-gtid-consistency=ON
       --gtid-mode=ON
 
+  mysql-source-message1:
+    image: mysql:8.0.40
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password
+      MYSQL_DATABASE: messagesystem
+      MYSQL_USER: dev_user
+      MYSQL_PASSWORD: dev_password
+    ports:
+      - "13308:3306"
+    volumes:
+      - ./data/mysql-source-message1:/var/lib/mysql
+      - ./init-scripts-source:/docker-entrypoint-initdb.d
+    command: >
+      --server-id=3
+      --log_bin=/var/lib/mysql/mysql-bin.log
+      --binlog-format=ROW
+      --enforce-gtid-consistency=ON
+      --gtid-mode=ON
+
+  mysql-replica-message1:
+    image: mysql:8.0.40
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password
+    ports:
+      - "13309:3306"
+    volumes:
+      - ./data/mysql-replica-message1:/var/lib/mysql
+      - ./init-scripts-replica-message1:/docker-entrypoint-initdb.d
+    depends_on:
+      mysql-source-message1:
+        condition: service_healthy
+    command: >
+      --server-id=4
+      --relay_log=/var/lib/mysql/mysql-relay-bin.log
+      --read_only=1
+      --enforce-gtid-consistency=ON
+      --gtid-mode=ON
+
+  mysql-source-message2:
+    image: mysql:8.0.40
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password
+      MYSQL_DATABASE: messagesystem
+      MYSQL_USER: dev_user
+      MYSQL_PASSWORD: dev_password
+    ports:
+      - "13310:3306"
+    volumes:
+      - ./data/mysql-source-message2:/var/lib/mysql
+      - ./init-scripts-source:/docker-entrypoint-initdb.d
+    command: >
+      --server-id=5
+      --log_bin=/var/lib/mysql/mysql-bin.log
+      --binlog-format=ROW
+      --enforce-gtid-consistency=ON
+      --gtid-mode=ON
+
+  mysql-replica-message2:
+    image: mysql:8.0.40
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password
+    ports:
+      - "13311:3306"
+    volumes:
+      - ./data/mysql-replica-message2:/var/lib/mysql
+      - ./init-scripts-replica-message2:/docker-entrypoint-initdb.d
+    depends_on:
+      mysql-source-message2:
+        condition: service_healthy
+    command: >
+      --server-id=6
+      --relay_log=/var/lib/mysql/mysql-relay-bin.log
+      --read_only=1
+      --enforce-gtid-consistency=ON
+      --gtid-mode=ON
+
   redis:
     image: redis:7.4.1
     ports:

--- a/docker/init-scripts-replica-message1/01-replication.sql
+++ b/docker/init-scripts-replica-message1/01-replication.sql
@@ -1,0 +1,7 @@
+CHANGE REPLICATION SOURCE TO
+  SOURCE_HOST = 'mysql-source-message1',
+  SOURCE_USER = 'replica_user',
+  SOURCE_PASSWORD = 'replica_password',
+  SOURCE_AUTO_POSITION = 1;
+
+START REPLICA;

--- a/docker/init-scripts-replica-message2/01-replication.sql
+++ b/docker/init-scripts-replica-message2/01-replication.sql
@@ -1,0 +1,7 @@
+CHANGE REPLICATION SOURCE TO
+  SOURCE_HOST = 'mysql-source-message2',
+  SOURCE_USER = 'replica_user',
+  SOURCE_PASSWORD = 'replica_password',
+  SOURCE_AUTO_POSITION = 1;
+
+START REPLICA;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "message-system-add-correction"
+rootProject.name = "message-system-add-sharding"

--- a/src/main/kotlin/com/narvi/messagesystem/config/DataSourceConfig.kt
+++ b/src/main/kotlin/com/narvi/messagesystem/config/DataSourceConfig.kt
@@ -1,6 +1,8 @@
 package com.narvi.messagesystem.config
 
 import com.narvi.messagesystem.database.RoutingDataSource
+import com.narvi.messagesystem.database.ShardContext
+import com.narvi.messagesystem.dto.domain.ChannelId
 import com.zaxxer.hikari.HikariDataSource
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Qualifier
@@ -9,7 +11,11 @@ import org.springframework.boot.jdbc.DataSourceBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
+import org.springframework.core.io.ClassPathResource
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy
+import org.springframework.jdbc.datasource.init.DataSourceInitializer
+import org.springframework.jdbc.datasource.init.DatabasePopulator
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator
 import javax.sql.DataSource
 
 @Configuration
@@ -25,23 +31,54 @@ class DataSourceConfig {
     @ConfigurationProperties(prefix = "spring.datasource.replica.hikari")
     fun replicaDataSource(): DataSource = DataSourceBuilder.create().type(HikariDataSource::class.java).build()
 
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.source-message1.hikari")
+    fun sourceMessage1DataSource(): DataSource = DataSourceBuilder.create().type(HikariDataSource::class.java).build()
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.replica-message1.hikari")
+    fun replicaMessage1DataSource(): DataSource = DataSourceBuilder.create().type(HikariDataSource::class.java).build()
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.source-message2.hikari")
+    fun sourceMessage2DataSource(): DataSource = DataSourceBuilder.create().type(HikariDataSource::class.java).build()
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.replica-message2.hikari")
+    fun replicaMessage2DataSource(): DataSource = DataSourceBuilder.create().type(HikariDataSource::class.java).build()
+
     // 요청의 목적(읽기/쓰기)에 따라 sourceDataSource 또는 replicaDataSource 를 자동으로 선택해 주는 라우팅 DataSource 를 제공
     @Bean
     fun routingDataSource(
         @Qualifier("sourceDataSource") sourceDataSource: DataSource,
         @Qualifier("replicaDataSource") replicaDataSource: DataSource,
+        @Qualifier("sourceMessage1DataSource") sourceMessage1DataSource: DataSource,
+        @Qualifier("replicaMessage1DataSource") replicaMessage1DataSource: DataSource,
+        @Qualifier("sourceMessage2DataSource") sourceMessage2DataSource: DataSource,
+        @Qualifier("replicaMessage2DataSource") replicaMessage2DataSource: DataSource,
     ): DataSource {
         val routingDataSource = RoutingDataSource()
         val targetDataSources: MutableMap<Any, Any> = HashMap()
 
         targetDataSources["source"] = sourceDataSource
         targetDataSources["replica"] = replicaDataSource
+        targetDataSources["sourceMessage1"] = sourceMessage1DataSource
+        targetDataSources["replicaMessage1"] = replicaMessage1DataSource
+        targetDataSources["sourceMessage2"] = sourceMessage2DataSource
+        targetDataSources["replicaMessage2"] = replicaMessage2DataSource
 
         routingDataSource.setTargetDataSources(targetDataSources)
-        routingDataSource.setDefaultTargetDataSource(sourceDataSource)
 
         replicaDataSource.connection.use {
             log.info("Init ReplicaConnectionPool.")
+        }
+
+        replicaMessage1DataSource.connection.use {
+            log.info("Init ReplicaMessage1ConnectionPool.")
+        }
+
+        replicaMessage2DataSource.connection.use {
+            log.info("Init ReplicaMessage2ConnectionPool.")
         }
 
         return routingDataSource
@@ -56,6 +93,46 @@ class DataSourceConfig {
     fun lazyConnectionDataSource(
         @Qualifier("routingDataSource") routingDataSource: DataSource
     ): DataSource = LazyConnectionDataSourceProxy(routingDataSource)
+
+    @Bean
+    fun sourceDataSourceInitializer(
+        sourceDataSource: DataSource
+    ): DataSourceInitializer = dataSourceInitializer(sourceDataSource, null)
+
+    @Bean
+    fun sourceMessage1DataSourceInitializer(
+        sourceMessage1DataSource: DataSource
+    ): DataSourceInitializer = dataSourceInitializer(sourceMessage1DataSource, ChannelId(1))
+
+    @Bean
+    fun sourceMessage2DataSourceInitializer(
+        sourceMessage2DataSource: DataSource
+    ): DataSourceInitializer = dataSourceInitializer(sourceMessage2DataSource, ChannelId(2))
+
+    private fun dataSourceInitializer(dataSource: DataSource, channelId: ChannelId?): DataSourceInitializer {
+        val initializer = DataSourceInitializer()
+        initializer.setDataSource(dataSource)
+
+        val populator = ResourceDatabasePopulator().apply {
+            if (channelId == null) {
+                addScripts(ClassPathResource("messagesystem.sql"))
+            } else {
+                addScripts(ClassPathResource("message.sql"))
+                ShardContext.setChannelId(channelId.id)
+            }
+        }
+
+        val wrapper = DatabasePopulator { connection ->
+            try {
+                populator.populate(connection)
+            } finally {
+                ShardContext.clear()
+            }
+        }
+
+        initializer.setDatabasePopulator(wrapper)
+        return initializer
+    }
 
     companion object {
         private val log = KotlinLogging.logger {}

--- a/src/main/kotlin/com/narvi/messagesystem/database/RoutingDataSource.kt
+++ b/src/main/kotlin/com/narvi/messagesystem/database/RoutingDataSource.kt
@@ -4,12 +4,23 @@ import mu.KotlinLogging
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource
 import org.springframework.transaction.support.TransactionSynchronizationManager
 
+/**
+ * Replica 및 Source 처리
+ * Message DB의 경우 channelId를 기준으로 모듈러 샤딩 처리
+ * - 홀수인 경우 -> Message1
+ * - 짝수인 경우 -> Message2
+ */
 class RoutingDataSource : AbstractRoutingDataSource() {
     override fun determineCurrentLookupKey(): Any {
-        val dataSourceKey =
+        var dataSourceKey =
             if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) "replica" else "source"
 
-        log.info("Routing to {} dataSource", dataSourceKey)
+        val channelId = ShardContext.getChannelId()
+        if (channelId != null) {
+            dataSourceKey += if (channelId % 2L == 0L) "Message2" else "Message1"
+        }
+
+        log.info("🚏 Routing to {} dataSource", dataSourceKey)
         return dataSourceKey
     }
 

--- a/src/main/kotlin/com/narvi/messagesystem/database/ShardContext.kt
+++ b/src/main/kotlin/com/narvi/messagesystem/database/ShardContext.kt
@@ -1,0 +1,26 @@
+package com.narvi.messagesystem.database
+
+object ShardContext {
+    private val threadLocal = ThreadLocal<Long>()
+
+    fun getChannelId(): Long? = threadLocal.get()
+
+    fun setChannelId(channelId: Long?) {
+        require(channelId != null) { "channelId cannot be null." }
+        threadLocal.set(channelId)
+    }
+
+    fun clear() {
+        threadLocal.remove()
+    }
+
+    class ShardContextScope(channelId: Long?) : AutoCloseable {
+        init {
+            setChannelId(channelId)
+        }
+
+        override fun close() {
+            clear()
+        }
+    }
+}

--- a/src/main/kotlin/com/narvi/messagesystem/service/ChannelService.kt
+++ b/src/main/kotlin/com/narvi/messagesystem/service/ChannelService.kt
@@ -6,7 +6,6 @@ import com.narvi.messagesystem.dto.domain.*
 import com.narvi.messagesystem.entity.ChannelEntity
 import com.narvi.messagesystem.entity.UserChannelEntity
 import com.narvi.messagesystem.repository.ChannelRepository
-import com.narvi.messagesystem.repository.MessageRepository
 import com.narvi.messagesystem.repository.UserChannelRepository
 import jakarta.persistence.EntityNotFoundException
 import mu.KotlinLogging
@@ -19,7 +18,7 @@ class ChannelService(
     private val userChannelRepository: UserChannelRepository,
     private val sessionService: SessionService,
     private val userConnectionService: UserConnectionService,
-    private val messageRepository: MessageRepository,
+    private val messageShardService: MessageShardService,
 ) {
 
     @Transactional(readOnly = true)
@@ -158,8 +157,7 @@ class ChannelService(
             return null to ResultType.NOT_FOUND
         }
 
-        val lastChannelMessageSeqId =
-            messageRepository.findLastMessageSequenceByChannelId(channelId.id)?.let(::MessageSeqId) ?: MessageSeqId(0L)
+        val lastChannelMessageSeqId = messageShardService.findLastMessageSequenceByChannelId(channelId)
 
         // 레디스에 해당 유저가 어떤 Channel 에 참가했는지에 대한 데이터 저장
         return if (sessionService.setActiveChannel(userId, channelId)) {

--- a/src/main/kotlin/com/narvi/messagesystem/service/MessageShardService.kt
+++ b/src/main/kotlin/com/narvi/messagesystem/service/MessageShardService.kt
@@ -1,0 +1,55 @@
+package com.narvi.messagesystem.service
+
+import com.narvi.messagesystem.database.ShardContext
+import com.narvi.messagesystem.dto.domain.ChannelId
+import com.narvi.messagesystem.dto.domain.MessageSeqId
+import com.narvi.messagesystem.dto.domain.UserId
+import com.narvi.messagesystem.dto.projection.MessageInfoProjection
+import com.narvi.messagesystem.entity.MessageEntity
+import com.narvi.messagesystem.repository.MessageRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * message db 로 가는 connection 은 항상 Shard 를 찾아야하고
+ * 항상 새로 맺어야 함
+ */
+@Service
+class MessageShardService(
+    private val messageRepository: MessageRepository
+) {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
+    fun findLastMessageSequenceByChannelId(channelId: ChannelId): MessageSeqId =
+        ShardContext.ShardContextScope(channelId.id).use {
+            messageRepository.findLastMessageSequenceByChannelId(channelId.id)?.let(::MessageSeqId) ?: MessageSeqId(0L)
+        }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
+    fun findByChannelIdAndMessageSequenceBetween(
+        channelId: ChannelId,
+        startMessageSeqId: MessageSeqId,
+        endMessageSeqId: MessageSeqId,
+    ): List<MessageInfoProjection> = ShardContext.ShardContextScope(channelId.id).use {
+        messageRepository.findByChannelIdAndMessageSequenceBetween(
+            channelId.id,
+            startMessageSeqId.id,
+            endMessageSeqId.id
+        )
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun save(channelId: ChannelId, messageSeqId: MessageSeqId, senderUserId: UserId, content: String) {
+        ShardContext.ShardContextScope(channelId.id).use {
+            messageRepository.save(
+                MessageEntity(
+                    channelId = channelId.id,
+                    messageSequence = messageSeqId.id,
+                    userId = senderUserId.id,
+                    content = content
+                )
+            )
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   application:
-    name: message-system-add-correction
+    name: message-system-add-sharding
   datasource:
     source:
       hikari:
@@ -27,9 +27,54 @@ spring:
         maximum-pool-size: 20
         idle-timeout: 60000
         connection-timeout: 30000
+    source-message1:
+      hikari:
+        jdbc-url: jdbc:mysql://localhost:13308/messagesystem
+        username: dev_user
+        password: dev_password
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        pool-name: SourceMessage1ConnectionPool
+        minimum-idle: 10
+        maximum-pool-size: 20
+        idle-timeout: 60000
+        connection-timeout: 30000
+    replica-message1:
+      hikari:
+        jdbc-url: jdbc:mysql://localhost:13309/messagesystem
+        username: dev_user
+        password: dev_password
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        pool-name: ReplicaMessage1ConnectionPool
+        minimum-idle: 10
+        maximum-pool-size: 20
+        idle-timeout: 60000
+        connection-timeout: 30000
+    source-message2:
+      hikari:
+        jdbc-url: jdbc:mysql://localhost:13310/messagesystem
+        username: dev_user
+        password: dev_password
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        pool-name: SourceMessage2ConnectionPool
+        minimum-idle: 10
+        maximum-pool-size: 20
+        idle-timeout: 60000
+        connection-timeout: 30000
+    replica-message2:
+      hikari:
+        jdbc-url: jdbc:mysql://localhost:13311/messagesystem
+        username: dev_user
+        password: dev_password
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        pool-name: ReplicaMessage2ConnectionPool
+        minimum-idle: 10
+        maximum-pool-size: 20
+        idle-timeout: 60000
+        connection-timeout: 30000
+
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: none
     open-in-view: false
     show-sql: true
     properties:
@@ -37,7 +82,7 @@ spring:
         format_sql: true
   sql:
     init:
-      mode: always
+      mode: never
   data:
     redis:
       host: localhost

--- a/src/main/resources/message.sql
+++ b/src/main/resources/message.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS message (
+    channel_id BIGINT NOT NULL,
+    message_sequence BIGINT NOT NULL,
+    user_id       BIGINT  NOT NULL,
+    content         VARCHAR(1000) NOT NULL,
+    created_at      TIMESTAMP     NOT NULL,
+    updated_at      TIMESTAMP     NOT NULL,
+    PRIMARY KEY (channel_id, message_sequence)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/messagesystem.sql
+++ b/src/main/resources/messagesystem.sql
@@ -1,14 +1,3 @@
-CREATE TABLE IF NOT EXISTS message (
-    channel_id BIGINT NOT NULL,
-    message_sequence BIGINT NOT NULL,
-    user_id       BIGINT  NOT NULL,
-    content         VARCHAR(1000) NOT NULL,
-    created_at      TIMESTAMP     NOT NULL,
-    updated_at      TIMESTAMP     NOT NULL,
-    PRIMARY KEY (channel_id, message_sequence)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
-
-
 CREATE TABLE IF NOT EXISTS message_user (
     user_id BIGINT AUTO_INCREMENT,
     username       VARCHAR(20)  NOT NULL,


### PR DESCRIPTION
- `2개의 message db source + 2개의 message db replica` = 총 4개의 message db 로 분리
- 나머지 2개의 db 는 message Entity 를 제외한 나머지 Entity 를 가지고 있는 1개의 source, 1개의 replica db

- 총 : 6개의 db

- 모듈러 사딩을 이용하여 `channelId` 를 기준으로 홀수는 1번, 짝수는 2번 db 를 바라보게 샤딩 처리